### PR TITLE
Add minimal Jekyll micro-blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_site/
+Gemfile.lock
+.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+
+group :jekyll_plugins do
+  gem 'jekyll-feed'
+  gem 'jekyll-seo-tag'
+end

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# gleb32.github.io
+# Monotweet
+
+A minimal, Twitter-inspired micro-blog built with Jekyll.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,24 @@
+# Site settings
+lang: en
+permalink: /:year/:slug/
+theme: null
+
+# Collections
+collections:
+  drafts:
+    output: false
+
+# Plugins
+plugins:
+  - jekyll-feed
+  - jekyll-seo-tag
+
+# Defaults
+defaults:
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: post
+
+excerpt_separator: "<!-- more -->"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,3 @@
+<footer class="site-footer">
+  <p>&copy; {{ site.time | date: '%Y' }} {{ site.title }}</p>
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,5 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+{% seo %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,3 @@
+<header class="site-header">
+  <h1><a href="{{ '/' | relative_url }}">{{ site.title }}</a></h1>
+</header>

--- a/_includes/tweet.html
+++ b/_includes/tweet.html
@@ -1,0 +1,9 @@
+<article class="post{% unless forloop.first %} wow-slide{% endunless %}">
+  <header>
+    <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d" }}</time>
+  </header>
+  <div class="body">{{ post.excerpt | strip_html | truncate: 280 }}</div>
+  <footer>
+    <a href="{{ post.url }}" aria-label="Permalink">&#x2192;</a>
+  </footer>
+</article>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
+  <head>
+    {% include head.html %}
+    <title>{{ page.title | default: site.title }}</title>
+  </head>
+  <body>
+    {% include header.html %}
+    <main>{{ content }}</main>
+    {% include footer.html %}
+  </body>
+</html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,8 @@
+---
+layout: default
+---
+<div class="timeline">
+  {% for post in site.posts %}
+    {% include tweet.html post=post %}
+  {% endfor %}
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,10 @@
+---
+layout: default
+---
+<article class="post-full">
+  <header>
+    <h1>{{ page.title }}</h1>
+    <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+  </header>
+  <div class="body">{{ content }}</div>
+</article>

--- a/_posts/2024-01-01-welcome.md
+++ b/_posts/2024-01-01-welcome.md
@@ -1,0 +1,4 @@
+---
+title: "Welcome to Monotweet"
+---
+This is the first micro‑post on the new blog. Stay tuned!<!-- more -->

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,0 +1,4 @@
+$accent: #087AE6;
+$bg: #FFFFFF;
+$text: #1F1F1F;
+$muted: #6E6E6E;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,37 @@
+@import 'variables';
+
+* { box-sizing: border-box; }
+body {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 17px; line-height: 1.6;
+  color: $text; background: $bg;
+  -webkit-font-smoothing: antialiased;
+}
+
+.timeline { max-width: 600px; margin: 3rem auto 6rem; }
+
+.post {
+  position: relative;
+  padding: 1.25rem 1rem 1rem 1.25rem;
+  border-left: 2px solid transparent;
+  transition: border-color .3s ease;
+  &:hover { border-color: $accent; }
+
+  header time { color: $muted; font-size: .85rem; }
+  .body { margin-top: .25rem; }
+
+  &:hover .body::after {
+    content: "|"; animation: blink 0.7s steps(1) infinite;
+    margin-left: .1rem; color: $accent;
+  }
+}
+
+@keyframes blink { 50% { opacity: 0; } }
+
+.wow-slide { opacity: 0; transform: translateX(-1rem); transition: 0.4s ease; }
+.wow-slide.visible { opacity: 1; transform: translateX(0); border-color: $accent; }
+
+body.dark {
+  background: #101215; color: #E5E7EB;
+  .post { border-color: rgba($accent, .4); }
+}

--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -1,0 +1,9 @@
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(e => e.isIntersecting && e.target.classList.add('visible'));
+});
+
+document.querySelectorAll('.wow-slide').forEach(el => observer.observe(el));
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'd') document.body.classList.toggle('dark');
+});

--- a/index.md
+++ b/index.md
@@ -1,0 +1,4 @@
+---
+layout: home
+title: Monotweet
+---


### PR DESCRIPTION
## Summary
- create minimal Jekyll blog with Monotweet layout
- add SCSS styles and variables
- include JavaScript for subtle animations
- configure Jekyll plugins and defaults
- add sample post and update README

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_683f5c6595a88333ace582f2e26a2f07