### PR TITLE
Fix SCSS compilation

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,3 +1,6 @@
+---
+---
+
 @import 'variables';
 
 * { box-sizing: border-box; }


### PR DESCRIPTION
## Summary
- add empty YAML front matter to `assets/css/style.scss` so Jekyll compiles it to CSS

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_683f5e18cf6083338948322277f51cd5