### PR TITLE
Add setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site/
 Gemfile.lock
 .bundle/
+vendor/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Monotweet
 
 A minimal, Twitter-inspired micro-blog built with Jekyll.
+
+## Local setup
+
+Install Ruby, then run the setup script to fetch the project's gems:
+
+```bash
+./scripts/setup.sh
+```
+
+When the installation finishes you can launch a local server with:
+
+```bash
+bundle exec jekyll serve
+```
+
+The site will be available at <http://localhost:4000>.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# Install bundler if not already installed
+if ! command -v bundle > /dev/null 2>&1; then
+  echo "Bundler not found. Installing Bundler..."
+  gem install bundler
+fi
+
+# Install project gems locally
+bundle config set --local path 'vendor/bundle'
+bundle install
+
+echo "\nAll gems installed. Run 'bundle exec jekyll serve' to start the site."


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` to install Ruby gems locally
- update `README.md` with setup instructions
- ignore `vendor/` directory

## Testing
- `./scripts/setup.sh`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_683f600a3d5083338803ca8b9971d8a4